### PR TITLE
Add KIOTA_OFFLINE_ENABLED environment variable

### DIFF
--- a/OpenAPI/kiota/using.md
+++ b/OpenAPI/kiota/using.md
@@ -23,6 +23,7 @@ The table below provides the list of environment variables that can be used to c
 | `KIOTA_CONSOLE_COLORS_ENABLED` | Enable/disable output colorization                                  | `true`        |
 | `KIOTA_CONSOLE_COLORS_SWAP`    | Enable/disable inverting the color scheme of the output             | `false`       |
 | `KIOTA_TUTORIAL_ENABLED`       | Enable/disable displaying additional hints after commands execution | `true`        |
+| `KIOTA_OFFLINE_ENABLED`        | Enable/disable checking for updates before commands execution       | `false`       |
 
 ## Commands
 


### PR DESCRIPTION
This adds the documentation for the use of the environment variable `KIOTA_OFFLINE_ENABLED`.

Related PR: https://github.com/microsoft/kiota/pull/4564