### PR TITLE
Add --ebc to Kiota quick start guides

### DIFF
--- a/OpenAPI/kiota/quickstarts/cli.md
+++ b/OpenAPI/kiota/quickstarts/cli.md
@@ -74,6 +74,11 @@ You can then use the Kiota command line tool to generate the API client classes.
 kiota generate -l CLI -c PostsClient -n KiotaPostsCLI.Client -d ./posts-api.yml -o ./src/Client
 ```
 
+> [!TIP]
+> Add [`--exclude-backward-compatible`](../using.md#--exclude-backward-compatible---ebc)
+> if you want to reduce the size of the generated client and are not concerned about
+> potentially source breaking changes with future versions of Kiota when updating the client.
+
 ## Create the client application
 
 The final step is to update the **Program.cs** file that was generated as part of the console application, replacing its contents with the following code.

--- a/OpenAPI/kiota/quickstarts/dotnet.md
+++ b/OpenAPI/kiota/quickstarts/dotnet.md
@@ -72,6 +72,11 @@ You can then use the Kiota command line tool to generate the API client classes.
 kiota generate -l CSharp -c PostsClient -n KiotaPosts.Client -d ./posts-api.yml -o ./Client
 ```
 
+> [!TIP]
+> Add [`--exclude-backward-compatible`](../using.md#--exclude-backward-compatible---ebc)
+> if you want to reduce the size of the generated client and are not concerned about
+> potentially source breaking changes with future versions of Kiota when updating the client.
+
 ## Create the client application
 
 The final step is to update the **Program.cs** file that was generated as part of the console application to include the following code.

--- a/OpenAPI/kiota/quickstarts/go.md
+++ b/OpenAPI/kiota/quickstarts/go.md
@@ -66,6 +66,11 @@ You can then use the Kiota command line tool to generate the API client classes.
 kiota generate -l go -c PostsClient -n kiota_posts/client -d ./posts-api.yml -o ./client
 ```
 
+> [!TIP]
+> Add [`--exclude-backward-compatible`](../using.md#--exclude-backward-compatible---ebc)
+> if you want to reduce the size of the generated client and are not concerned about
+> potentially source breaking changes with future versions of Kiota when updating the client.
+
 ## Create the client application
 
 Create a file in the root of the project named **main.go** and add the following code.

--- a/OpenAPI/kiota/quickstarts/java.md
+++ b/OpenAPI/kiota/quickstarts/java.md
@@ -65,6 +65,11 @@ You can then use the Kiota command line tool to generate the API client classes.
 kiota generate -l java -c PostsClient -n kiotaposts.client -d ./posts-api.yml -o ./app/src/main/java/kiotaposts/client
 ```
 
+> [!TIP]
+> Add [`--exclude-backward-compatible`](../using.md#--exclude-backward-compatible---ebc)
+> if you want to reduce the size of the generated client and are not concerned about
+> potentially source breaking changes with future versions of Kiota when updating the client.
+
 ## Create the client application
 
 The final step is to update the **./app/src/main/java/kiotaposts/App.java** file that was generated as part of the console application, replacing its contents with the following code.

--- a/OpenAPI/kiota/quickstarts/php.md
+++ b/OpenAPI/kiota/quickstarts/php.md
@@ -63,6 +63,11 @@ You can then use the Kiota command line tool to generate the API client classes.
 kiota generate -l PHP -d ../posts-api.yml -c PostsApiClient -n KiotaPosts\Client -o ./client
 ```
 
+> [!TIP]
+> Add [`--exclude-backward-compatible`](../using.md#--exclude-backward-compatible---ebc)
+> if you want to reduce the size of the generated client and are not concerned about
+> potentially source breaking changes with future versions of Kiota when updating the client.
+
 Add the following to your `composer.json` to set your namespaces correctly:
 
 ```json

--- a/OpenAPI/kiota/quickstarts/python.md
+++ b/OpenAPI/kiota/quickstarts/python.md
@@ -65,6 +65,11 @@ You can then use the Kiota command line tool to generate the API client classes.
 kiota generate -l python -c PostsClient -n client -d ./posts-api.yml -o ./client
 ```
 
+> [!TIP]
+> Add [`--exclude-backward-compatible`](../using.md#--exclude-backward-compatible---ebc)
+> if you want to reduce the size of the generated client and are not concerned about
+> potentially source breaking changes with future versions of Kiota when updating the client.
+
 ## Create the client application
 
 Create a file in the root of the project named **main.py** and add the following code.

--- a/OpenAPI/kiota/quickstarts/typescript.md
+++ b/OpenAPI/kiota/quickstarts/typescript.md
@@ -74,6 +74,11 @@ You can then use the Kiota command line tool to generate the API client classes.
 kiota generate -l typescript -d posts-api.yml -c PostsClient -o ./client
 ```
 
+> [!TIP]
+> Add [`--exclude-backward-compatible`](../using.md#--exclude-backward-compatible---ebc)
+> if you want to reduce the size of the generated client and are not concerned about
+> potentially source breaking changes with future versions of Kiota when updating the client.
+
 ## Create the client application
 
 Create a file in the root of the project named **index.ts** and add the following code.


### PR DESCRIPTION
Add tip to specify `--exclude-backward-compatible` in quick start guides for new Kiota clients.

Resolves #101.
