### PR TITLE
Fix incorrect TS middleware example

### DIFF
--- a/OpenAPI/kiota/middleware.md
+++ b/OpenAPI/kiota/middleware.md
@@ -38,7 +38,7 @@ public class SaveRequestHandler : DelegatingHandler
 ```typescript
 export class SaveRequestHandler implements Middleware {
     next: Middleware | undefined;
-    public execute(url: string, requestInit: RequestInit, requestOptions?: Record<string, RequestOption>): Promise<Response> {
+    public async execute(url: string, requestInit: RequestInit, requestOptions?: Record<string, RequestOption>): Promise<Response> {
         console.log(`Request: ${requestInit.body}`);
         return await this.next?.execute(url, requestInit as RequestInit, requestOptions);
     }


### PR DESCRIPTION
Function block should be `async` in order to use `await`