### PR TITLE
Update virtual environment recommendation in python.md

### DIFF
--- a/OpenAPI/kiota/quickstarts/python.md
+++ b/OpenAPI/kiota/quickstarts/python.md
@@ -49,7 +49,7 @@ pip install microsoft-kiota-serialization-multipart
 ```
 
 > [!TIP]
-> It is recommended to use a package manager/virtual environment to avoid installing packages system wide. Read more [here](https://packaging.python.org/en/latest/).
+> It is recommended to use a package manager/virtual environment(.venv) to avoid installing packages system wide. Read more [here](https://packaging.python.org/en/latest/).
 
 ## Generate the API client
 


### PR DESCRIPTION
Clarified the recommendation for using a virtual environment by specifying '.venv'.