### PR TITLE
docs(kiota): add TypeScript example for scrubbing custom headers on redirects

### DIFF
--- a/OpenAPI/kiota/middleware.md
+++ b/OpenAPI/kiota/middleware.md
@@ -196,8 +196,34 @@ var handlers = KiotaClientFactory.CreateDefaultHandlers(new IRequestOption[] { r
 
 ### [TypeScript](#tab/typescript)
 
-> [!NOTE]
-> A composable way to remove custom headers while preserving the built-in scrubbing isn't available yet in the TypeScript library, because the default scrubbing implementation isn't exposed for reuse. Until then, avoid attaching custom API key or authorization headers to requests that can be redirected across origins.
+```typescript
+import {
+    KiotaClientFactory,
+    MiddlewareFactory,
+    RedirectHandler,
+    RedirectHandlerOptions,
+    defaultScrubSensitiveHeaders,
+} from "@microsoft/kiota-http-fetchlibrary";
+
+const redirectOptions = new RedirectHandlerOptions({
+    scrubSensitiveHeaders: (headers, originalUrl, newUrl) => {
+        // Keep the default scrubbing of Authorization, Cookie, and Proxy-Authorization.
+        defaultScrubSensitiveHeaders(headers, originalUrl, newUrl);
+
+        // Remove your custom API key header on redirect.
+        // Header keys are lower-cased before they reach the middleware.
+        delete headers["x-api-key"];
+    },
+});
+
+// Start from the default middleware chain and replace the redirect handler
+// with one configured to scrub the custom header.
+const middlewares = MiddlewareFactory.getDefaultMiddlewares();
+const redirectIndex = middlewares.findIndex((handler) => handler instanceof RedirectHandler);
+middlewares[redirectIndex] = new RedirectHandler(redirectOptions);
+
+const httpClient = KiotaClientFactory.create(undefined, middlewares);
+```
 
 ### [Python](#tab/python)
 


### PR DESCRIPTION
Adds a TypeScript code example to the "Scrubbing sensitive headers on redirects" section, matching the existing .NET and Python examples.

The example composes with the exported `defaultScrubSensitiveHeaders` function so the built-in scrubbing of `Authorization`, `Cookie`, and `Proxy-Authorization` is preserved while a custom API key header is also removed on cross-origin redirects.

Requires the `@microsoft/kiota-http-fetchlibrary` release that includes microsoft/kiota-typescript#2087; will be published once that release ships.

See https://portal.microsofticm.com/imp/v5/incidents/details/31000000667652/summary